### PR TITLE
feat(keyboard): add keyup support to bindKeys (#201)

### DIFF
--- a/examples/sprite/controllingASprite.html
+++ b/examples/sprite/controllingASprite.html
@@ -60,6 +60,10 @@
       e.preventDefault();
     });
 
+    kontra.bindKeys(['up', 'down', 'left', 'right'], function(e) {
+      console.log('key released: ', e)
+    }, 'keyup');
+
     // create the game loop to update and render the sprite
     window.loop = kontra.GameLoop({
       update: function() {

--- a/src/keyboard.js
+++ b/src/keyboard.js
@@ -26,7 +26,8 @@
  * @sectionName Available Keys
  */
 
-let callbacks = {};
+let keydownCallbacks = {};
+let keyupCallbacks = {};
 let pressedKeys = {};
 
 /**
@@ -63,8 +64,8 @@ function keydownEventHandler(evt) {
   let key = keyMap[evt.code];
   pressedKeys[key] = true;
 
-  if (callbacks[key]) {
-    callbacks[key](evt);
+  if (keydownCallbacks[key]) {
+    keydownCallbacks[key](evt);
   }
 }
 
@@ -74,7 +75,12 @@ function keydownEventHandler(evt) {
  * @param {KeyboardEvent} evt
  */
 function keyupEventHandler(evt) {
-  pressedKeys[ keyMap[evt.code] ] = false;
+  let key = keyMap[evt.code];
+  pressedKeys[key] = false;
+
+  if (keyupCallbacks[key]) {
+    keyupCallbacks[key](evt);
+  }
 }
 
 /**
@@ -119,7 +125,7 @@ export function initKeys() {
  *
  * bindKeys('p', function(e) {
  *   // pause the game
- * });
+ * }, 'keyup');
  * bindKeys(['enter', 'space'], function(e) {
  *   e.preventDefault();
  *   // fire gun
@@ -129,8 +135,10 @@ export function initKeys() {
  *
  * @param {String|String[]} keys - Key or keys to bind.
  * @param {(evt: KeyboardEvent) => void} callback - The function to be called when the key is pressed.
+ * @param {'keydown'|'keyup'} [handler=keydown] - Whether to bind to keydown or keyup events.
  */
-export function bindKeys(keys, callback) {
+export function bindKeys(keys, callback, handler='keydown') {
+  const callbacks = handler == 'keydown' ? keydownCallbacks : keyupCallbacks;
   // smaller than doing `Array.isArray(keys) ? keys : [keys]`
   [].concat(keys).map(key => callbacks[key] = callback);
 }
@@ -147,8 +155,10 @@ export function bindKeys(keys, callback) {
  * @function unbindKeys
  *
  * @param {String|String[]} keys - Key or keys to unbind.
+ * @param {'keydown'|'keyup'} [handler=keydown] - Whether to unbind from keydown or keyup events.
  */
-export function unbindKeys(keys) {
+export function unbindKeys(keys, handler='keydown') {
+  const callbacks = handler == 'keydown' ? keydownCallbacks : keyupCallbacks;
   // 0 is the smallest falsy value
   [].concat(keys).map(key => callbacks[key] = 0);
 }

--- a/test/unit/keyboard.spec.js
+++ b/test/unit/keyboard.spec.js
@@ -105,24 +105,54 @@ describe('keyboard', () => {
   // --------------------------------------------------
   describe('bind', () => {
 
-    it('should call the callback when a single key combination is pressed', (done) => {
-      keyboard.bindKeys('a', evt => {
-        done();
+    // Defaults to keydown
+    describe('handler=keydown', () => {
+
+      it('should call the callback when a single key combination is pressed', (done) => {
+        keyboard.bindKeys('a', evt => {
+          done();
+        });
+
+        simulateEvent('keydown', {code: 'KeyA'});
+
+        throw new Error('should not get here');
       });
 
-      simulateEvent('keydown', {code: 'KeyA'});
+      it('should accept an array of key combinations to bind', (done) => {
+        keyboard.bindKeys(['a', 'b'], evt => {
+          done();
+        });
 
-      throw new Error('should not get here');
+        simulateEvent('keydown', {code: 'KeyB'});
+
+        throw new Error('should not get here');
+      });
+
     });
 
-    it('should accept an array of key combinations to bind', (done) => {
-      keyboard.bindKeys(['a', 'b'], evt => {
-        done();
+    describe('handler=keyup', () => {
+      const handler = 'keyup';
+
+      it('should call the callback when a single key combination is pressed', (done) => {
+        keyboard.bindKeys('a', evt => {
+          done();
+        }, handler);
+
+        simulateEvent('keyup', {code: 'KeyA'});
+
+        throw new Error('should not get here');
       });
 
-      simulateEvent('keydown', {code: 'KeyB'});
+      it('should accept an array of key combinations to bind', (done) => {
+        keyboard.bindKeys(['a', 'b'], evt => {
+          done();
+        }, handler);
 
-      throw new Error('should not get here');
+        simulateEvent('keyup', {code: 'KeyB'});
+
+        throw new Error('should not get here');
+      });
+
     });
 
   });
@@ -136,27 +166,60 @@ describe('keyboard', () => {
   // --------------------------------------------------
   describe('unbind', () => {
 
-    it('should not call the callback when the combination has been unbound', () => {
-      keyboard.bindKeys('a', () => {
-        // this should never be called since the key combination was unbound
-        expect(false).to.be.true;
+    // Defaults to keydown
+    describe('handler=keydown', () => {
+
+      it('should not call the callback when the combination has been unbound', () => {
+        keyboard.bindKeys('a', () => {
+          // this should never be called since the key combination was unbound
+          expect(false).to.be.true;
+        });
+
+        keyboard.unbindKeys('a');
+
+        simulateEvent('keydown', {which: 65});
       });
 
-      keyboard.unbindKeys('a');
+      it('should accept an array of key combinations to unbind', () => {
+        keyboard.bindKeys(['a', 'b'], () => {
+          // this should never be called since the key combination was unbound
+          expect(false).to.be.true;
+        });
 
-      simulateEvent('keydown', {which: 65});
+        keyboard.unbindKeys(['a', 'b']);
+
+        simulateEvent('keydown', {which: 65});
+        simulateEvent('keydown', {which: 66});
+      });
+
     });
 
-    it('should accept an array of key combinations to unbind', () => {
-      keyboard.bindKeys(['a', 'b'], () => {
-        // this should never be called since the key combination was unbound
-        expect(false).to.be.true;
+    describe('handler=keyup', () => {
+      const handler = 'keyup'
+
+      it('should not call the callback when the combination has been unbound', () => {
+        keyboard.bindKeys('a', () => {
+          // this should never be called since the key combination was unbound
+          expect(false).to.be.true;
+        }, handler);
+
+        keyboard.unbindKeys('a');
+
+        simulateEvent('keyup', {which: 65});
       });
 
-      keyboard.unbindKeys(['a', 'b']);
+      it('should accept an array of key combinations to unbind', () => {
+        keyboard.bindKeys(['a', 'b'], () => {
+          // this should never be called since the key combination was unbound
+          expect(false).to.be.true;
+        }, handler);
 
-      simulateEvent('keydown', {which: 65});
-      simulateEvent('keydown', {which: 66});
+        keyboard.unbindKeys(['a', 'b']);
+
+        simulateEvent('keyup', {which: 65});
+        simulateEvent('keyup', {which: 66});
+      });
+
     });
 
   });


### PR DESCRIPTION
* Add keyup support to bindKeys

To enable responding to keyup events, allow passing in an optional
`handler` param to `#bindKeys` that specifies which event handler to
apply callbacks to.

* Fix typescript type, add unbind test